### PR TITLE
Create OpenNMS ferm IP tables rules

### DIFF
--- a/state/opennms/common.sls
+++ b/state/opennms/common.sls
@@ -1,0 +1,8 @@
+# Firewall configuration
+#
+# Hardening OpenNMS and don't allow RMI 1099 port on IPv4 and IPv6
+ferm.opennms.common:
+   file.managed:
+     - name: /etc/ferm.d/20-opennms-common.conf
+     - source: salt://opennms/ferm.common.conf
+     - makedirs: True

--- a/state/opennms/ferm.common.conf
+++ b/state/opennms/ferm.common.conf
@@ -1,0 +1,25 @@
+# DO NOT CHANGE THIS FILE IT IS CONTROLLED BY SALTSTACK!
+#
+# IPv4 / IPv6 firewall
+# - RMI registry 1099
+# - Apache Karaf admin console
+# - JMX monitoring
+# - Active MQ
+#
+domain ip
+table filter {
+  chain INPUT {
+    proto tcp dport (1099 8101 18980 61616)  {
+      saddr 127.0.0.1/32 ACCEPT;
+    }
+  }
+}
+
+domain ip6
+table filter {
+  chain INPUT {
+    proto tcp dport  (1099 8101 18980 61616) {
+      saddr ::1/128 ACCEPT;
+    }
+  }
+}

--- a/state/opennms/ferm.syslogd.conf
+++ b/state/opennms/ferm.syslogd.conf
@@ -1,0 +1,10 @@
+# DO NOT CHANGE THIS FILE IT IS CONTROLLED BY SALTSTACK!
+#
+# IPv4 / IPv6 firewall - Syslog daemon rule
+
+domain (ip ip6)
+table filter {
+  chain INPUT {
+    proto udp dport 10514 ACCEPT;
+  }
+}

--- a/state/opennms/ferm.trapd.conf
+++ b/state/opennms/ferm.trapd.conf
@@ -1,0 +1,10 @@
+# DO NOT CHANGE THIS FILE IT IS CONTROLLED BY SALTSTACK!
+#
+# IPv4 / IPv6 firewall - SNMP Trap daemon rule
+
+domain (ip ip6)
+table filter {
+  chain INPUT {
+    proto udp dport 162 ACCEPT;
+  }
+}

--- a/state/opennms/ferm.web.conf
+++ b/state/opennms/ferm.web.conf
@@ -1,0 +1,13 @@
+# DO NOT CHANGE THIS FILE IT IS CONTROLLED BY SALTSTACK!
+#
+# IPv4 / IPv6 firewall - Web application rule
+
+domain (ip ip6)
+table filter {
+  chain INPUT {
+    proto tcp dport 8980 {
+      mod conntrack ctstate NEW
+      ACCEPT;
+    }
+  }
+}

--- a/state/opennms/syslogd.sls
+++ b/state/opennms/syslogd.sls
@@ -1,0 +1,9 @@
+# Firewall configuration
+#
+
+# Allow OpenNMS to receive Syslog messages
+ferm.opennms.syslogd:
+  file.managed:
+    - name: /etc/ferm.d/20-opennms-syslogd.conf
+    - source: salt://opennms/ferm.syslogd.conf
+    - makedirs: True

--- a/state/opennms/trapd.sls
+++ b/state/opennms/trapd.sls
@@ -1,0 +1,9 @@
+# Firewall configuration
+#
+
+# Allow OpenNMS to receive SNMP Traps
+ferm.opennms.trapd:
+  file.managed:
+    - name: /etc/ferm.d/20-opennms-trapd.conf
+    - source: salt://opennms/ferm.trapd.conf
+    - makedirs: True

--- a/state/opennms/web.sls
+++ b/state/opennms/web.sls
@@ -1,0 +1,9 @@
+# Firewall configuration
+#
+
+# Allow access to the WebUI
+ferm.opennms.web:
+  file.managed:
+    - name: /etc/ferm.d/20-opennms-web.conf
+    - source: salt://opennms/ferm.web.conf
+    - makedirs: True


### PR DESCRIPTION
Create OpenNMS ferm IP tables rules and allow to divide policies for several components like WebUI, Trapd, Syslogd. Lockdown all common management ports to localhost only.

Resolves: #5 
